### PR TITLE
Revert drag and drop, as it doesn't work on Safari (desktop)

### DIFF
--- a/frontend/src/components/lists/data.jsx
+++ b/frontend/src/components/lists/data.jsx
@@ -21,14 +21,8 @@ export default class ListsData extends React.Component {
     constructor(props) {
         super(props);
         this.edit = this.edit.bind(this);
-        this.onDragStart = this.onDragStart.bind(this);
-        this.onDragEnter = this.onDragEnter.bind(this);
-        this.onDragOver = this.onDragOver.bind(this);
-        this.onDrop = this.onDrop.bind(this);
         this.move = this.move.bind(this);
         this.delete = this.delete.bind(this);
-
-        this.state = {};
     }
 
     selectComment(id, type) {
@@ -37,49 +31,6 @@ export default class ListsData extends React.Component {
 
     edit(item) {
         this.props.onEdit(item.id);
-    }
-
-    onDragStart(e, item) {
-        // Hide default thumbnail
-        e.dataTransfer.setDragImage(new Image(), 0, 0);
-
-        this.setState({
-            draggingItem: item,
-            draggingData: this.props.data
-        });
-    }
-
-    onDragEnter(e, draggedOverId) {
-        // Required so that onDrop fires (https://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html)
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copyMove';
-
-        const { draggingItem } = this.state;
-
-        if(draggingItem.id !== draggedOverId) {
-            const draggingData = this.state.draggingData.filter(item => item.id !== draggingItem.id);
-
-            const dropId = this.state.draggingData.findIndex(item => item.id === draggedOverId);
-            draggingData.splice(dropId, 0, this.state.draggingItem);
-
-            this.setState({ draggingData });
-        }
-    }
-
-    onDragOver(e) {
-        // Required so that onDrop fires (https://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html)
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copyMove';
-    }
-
-    onDrop() {
-        const { draggingItem } = this.state;
-
-        const pos = this.props.data.indexOf(draggingItem);
-        const newPos = this.state.draggingData.indexOf(draggingItem);
-
-        this.move(pos, newPos);
-        this.setState({ draggingData: undefined, draggingItem: undefined });
     }
 
     move(pos, newPos) {
@@ -94,11 +45,9 @@ export default class ListsData extends React.Component {
     render() {
 
         const { id, type } = this.props.selectedComment || { id: null, type: null };
+        const length = this.props.data.length;
 
-        const draggingId = this.state.draggingItem ? this.state.draggingItem.id : undefined; 
-        const data = this.state.draggingData || this.props.data;
-
-        const tableRows = data.map((item, rowIndex) => {
+        const tableRows = this.props.data.map((item, rowIndex) => {
             const isSelected = t => id === rowIndex && t === type;
             const cells = columns.map((col, colIndex) => {
                 return (
@@ -115,22 +64,16 @@ export default class ListsData extends React.Component {
             return (
                 <tr
                     key={rowIndex}
-                    className={item.id === draggingId ? 'dragging-item' : ''}
-                    // preventDefault calls required to get onDrop to fire
-                    onDragEnter={(e) => this.onDragEnter(e, item.id)}
-                    onDragOver={this.onDragOver}
-                    onDrop={this.onDrop}
                 >
-                    <td
-                        className="action-cell action-cell-draggable"
-                        draggable
-                        onDragStart={(e) => this.onDragStart(e, item)}
-                    >
-                        <FontAwesomeIcon icon="bars" />
-                    </td>
                     <td>{ item.description }</td>
                     { cells }
                     <td className="action-cell">
+                        <span className={ 'item-action' + (rowIndex === 0 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex - 1) }>
+                            <FontAwesomeIcon icon="arrow-up" />
+                        </span>
+                        <span className={ 'item-action' + (rowIndex === length - 1 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex + 1) }>
+                            <FontAwesomeIcon icon="arrow-down" />
+                        </span>
                         <span className="item-action primary" onClick={ () => this.edit(item) }>
                             <FontAwesomeIcon icon="edit" />
                         </span>
@@ -146,13 +89,11 @@ export default class ListsData extends React.Component {
             <table className="lists-data">
                 <thead>
                     <tr>
-                        <th></th>
                         <th rowSpan="2">Description</th>
                         <th colSpan="5" className="first">Quantities and Notes</th>
                         <th></th>
                     </tr>
                     <tr>
-                        <th></th>
                         <th>Single</th>
                         <th>Family of 2</th>
                         <th>Family of 3</th>

--- a/frontend/src/components/lists/styles/data.scss
+++ b/frontend/src/components/lists/styles/data.scss
@@ -8,10 +8,6 @@
         text-align: right;
     }
 
-    .action-cell-draggable {
-        cursor: move;
-    }
-
     .item-action {
 
         color: $colour-text-secondary;
@@ -48,8 +44,4 @@
             margin-left: $pad-half;
         }
     }
-}
-
-.dragging-item {
-    @include shadow
 }

--- a/frontend/src/icons/index.js
+++ b/frontend/src/icons/index.js
@@ -16,8 +16,7 @@ import {
     faSignOutAlt,
     faSpinner,
     faTimes,
-    faUser,
-    faBars
+    faUser
 } from '@fortawesome/free-solid-svg-icons'
 import {
     faSave
@@ -44,8 +43,7 @@ export default function setupIcons() {
         faSignOutAlt,
         faSpinner,
         faTimes,
-        faUser,
-        faBars
+        faUser
     );
 
     // Regular icons


### PR DESCRIPTION
Reverts #59 and #57 whilst maintaining the changes in #58 to show more family sizes in the shopping list