### PR TITLE
Drag and drop shopping list (take 2 with Safari support)

### DIFF
--- a/frontend/src/components/lists/data.jsx
+++ b/frontend/src/components/lists/data.jsx
@@ -100,6 +100,7 @@ export default class ListsData extends React.Component {
     render() {
 
         const { id, type } = this.props.selectedComment || { id: null, type: null };
+        const length = this.props.data.length;
 
         const draggingId = this.state.draggingItem ? this.state.draggingItem.id : undefined; 
         const data = this.state.draggingData || this.props.data;
@@ -137,17 +138,17 @@ export default class ListsData extends React.Component {
                     <td>{ item.description }</td>
                     { cells }
                     <td className="action-cell">
+                        <span className={ 'item-action' + (rowIndex === 0 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex - 1) }>
+                            <FontAwesomeIcon icon="arrow-up" />
+                        </span>
+                        <span className={ 'item-action' + (rowIndex === length - 1 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex + 1) }>
+                            <FontAwesomeIcon icon="arrow-down" />
+                        </span>
                         <span className="item-action primary" onClick={ () => this.edit(item) }>
                             <FontAwesomeIcon icon="edit" />
                         </span>
                         <span className="item-action danger" onClick={ () => this.delete(item) }>
                             <FontAwesomeIcon icon="times" />
-                        </span>
-                        <span className={ 'item-action' + (rowIndex === 0 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex - 1) }>
-                            <FontAwesomeIcon icon="arrow-up" />
-                        </span>
-                        <span className={ 'item-action' + (rowIndex === data.length - 1 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex + 1) }>
-                            <FontAwesomeIcon icon="arrow-down" />
                         </span>
                     </td>
                 </tr>

--- a/frontend/src/components/lists/data.jsx
+++ b/frontend/src/components/lists/data.jsx
@@ -21,8 +21,14 @@ export default class ListsData extends React.Component {
     constructor(props) {
         super(props);
         this.edit = this.edit.bind(this);
+        this.onDragStart = this.onDragStart.bind(this);
+        this.onDragEnter = this.onDragEnter.bind(this);
+        this.onDragOver = this.onDragOver.bind(this);
+        this.onDrop = this.onDrop.bind(this);
         this.move = this.move.bind(this);
         this.delete = this.delete.bind(this);
+
+        this.state = {};
     }
 
     selectComment(id, type) {
@@ -31,6 +37,49 @@ export default class ListsData extends React.Component {
 
     edit(item) {
         this.props.onEdit(item.id);
+    }
+
+    onDragStart(e, item) {
+        // Hide default thumbnail
+        e.dataTransfer.setDragImage(new Image(), 0, 0);
+
+        this.setState({
+            draggingItem: item,
+            draggingData: this.props.data
+        });
+    }
+
+    onDragEnter(e, draggedOverId) {
+        // Required so that onDrop fires (https://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html)
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copyMove';
+
+        const { draggingItem } = this.state;
+
+        if(draggingItem.id !== draggedOverId) {
+            const draggingData = this.state.draggingData.filter(item => item.id !== draggingItem.id);
+
+            const dropId = this.state.draggingData.findIndex(item => item.id === draggedOverId);
+            draggingData.splice(dropId, 0, this.state.draggingItem);
+
+            this.setState({ draggingData });
+        }
+    }
+
+    onDragOver(e) {
+        // Required so that onDrop fires (https://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html)
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copyMove';
+    }
+
+    onDrop() {
+        const { draggingItem } = this.state;
+
+        const pos = this.props.data.indexOf(draggingItem);
+        const newPos = this.state.draggingData.indexOf(draggingItem);
+
+        this.move(pos, newPos);
+        this.setState({ draggingData: undefined, draggingItem: undefined });
     }
 
     move(pos, newPos) {
@@ -45,9 +94,11 @@ export default class ListsData extends React.Component {
     render() {
 
         const { id, type } = this.props.selectedComment || { id: null, type: null };
-        const length = this.props.data.length;
 
-        const tableRows = this.props.data.map((item, rowIndex) => {
+        const draggingId = this.state.draggingItem ? this.state.draggingItem.id : undefined; 
+        const data = this.state.draggingData || this.props.data;
+
+        const tableRows = data.map((item, rowIndex) => {
             const isSelected = t => id === rowIndex && t === type;
             const cells = columns.map((col, colIndex) => {
                 return (
@@ -64,16 +115,22 @@ export default class ListsData extends React.Component {
             return (
                 <tr
                     key={rowIndex}
+                    className={item.id === draggingId ? 'dragging-item' : ''}
+                    // preventDefault calls required to get onDrop to fire
+                    onDragEnter={(e) => this.onDragEnter(e, item.id)}
+                    onDragOver={this.onDragOver}
+                    onDrop={this.onDrop}
                 >
+                    <td
+                        className="action-cell action-cell-draggable"
+                        draggable
+                        onDragStart={(e) => this.onDragStart(e, item)}
+                    >
+                        <FontAwesomeIcon icon="bars" />
+                    </td>
                     <td>{ item.description }</td>
                     { cells }
                     <td className="action-cell">
-                        <span className={ 'item-action' + (rowIndex === 0 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex - 1) }>
-                            <FontAwesomeIcon icon="arrow-up" />
-                        </span>
-                        <span className={ 'item-action' + (rowIndex === length - 1 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex + 1) }>
-                            <FontAwesomeIcon icon="arrow-down" />
-                        </span>
                         <span className="item-action primary" onClick={ () => this.edit(item) }>
                             <FontAwesomeIcon icon="edit" />
                         </span>
@@ -89,11 +146,13 @@ export default class ListsData extends React.Component {
             <table className="lists-data">
                 <thead>
                     <tr>
+                        <th></th>
                         <th rowSpan="2">Description</th>
                         <th colSpan="5" className="first">Quantities and Notes</th>
                         <th></th>
                     </tr>
                     <tr>
+                        <th></th>
                         <th>Single</th>
                         <th>Family of 2</th>
                         <th>Family of 3</th>

--- a/frontend/src/components/lists/data.jsx
+++ b/frontend/src/components/lists/data.jsx
@@ -29,6 +29,12 @@ export default class ListsData extends React.Component {
         this.delete = this.delete.bind(this);
 
         this.state = {};
+
+        // Drag and drop won't work in Safari if we try to construct the image inline
+        // and empty. The workaround is to use an empty GIF as the source for the image
+        // and build it before the drag operations are started
+        this.transparentDragImage = new Image();
+        this.transparentDragImage.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
     }
 
     selectComment(id, type) {
@@ -41,7 +47,7 @@ export default class ListsData extends React.Component {
 
     onDragStart(e, item) {
         // Hide default thumbnail
-        e.dataTransfer.setDragImage(new Image(), 0, 0);
+        e.dataTransfer.setDragImage(this.transparentDragImage, 0, 0);
 
         this.setState({
             draggingItem: item,

--- a/frontend/src/components/lists/data.jsx
+++ b/frontend/src/components/lists/data.jsx
@@ -143,6 +143,12 @@ export default class ListsData extends React.Component {
                         <span className="item-action danger" onClick={ () => this.delete(item) }>
                             <FontAwesomeIcon icon="times" />
                         </span>
+                        <span className={ 'item-action' + (rowIndex === 0 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex - 1) }>
+                            <FontAwesomeIcon icon="arrow-up" />
+                        </span>
+                        <span className={ 'item-action' + (rowIndex === data.length - 1 ? ' disabled' : '') } onClick={ () => this.move(rowIndex, rowIndex + 1) }>
+                            <FontAwesomeIcon icon="arrow-down" />
+                        </span>
                     </td>
                 </tr>
             );

--- a/frontend/src/components/lists/styles/data.scss
+++ b/frontend/src/components/lists/styles/data.scss
@@ -51,5 +51,9 @@
 }
 
 .dragging-item {
-    @include shadow
+    background-color: $colour-background-primary;
+}
+
+.dragging-item:nth-child(even) {
+    background-color: $colour-background-primary;
 }

--- a/frontend/src/components/lists/styles/data.scss
+++ b/frontend/src/components/lists/styles/data.scss
@@ -8,6 +8,10 @@
         text-align: right;
     }
 
+    .action-cell-draggable {
+        cursor: move;
+    }
+
     .item-action {
 
         color: $colour-text-secondary;
@@ -44,4 +48,8 @@
             margin-left: $pad-half;
         }
     }
+}
+
+.dragging-item {
+    @include shadow
 }

--- a/frontend/src/icons/index.js
+++ b/frontend/src/icons/index.js
@@ -16,7 +16,8 @@ import {
     faSignOutAlt,
     faSpinner,
     faTimes,
-    faUser
+    faUser,
+    faBars
 } from '@fortawesome/free-solid-svg-icons'
 import {
     faSave
@@ -43,7 +44,8 @@ export default function setupIcons() {
         faSignOutAlt,
         faSpinner,
         faTimes,
-        faUser
+        faUser,
+        faBars
     );
 
     // Regular icons


### PR DESCRIPTION
#57 again but fixing Safari support and retaining the up/down buttons just in case (and for touch devices that can't drag and drop). Unfortunately we had to lose the box-shadow because it doesn't work on table rows in Safari.

![ce14edf1d4bab835d80040ae1e1955b1](https://user-images.githubusercontent.com/395805/101462237-e4392e00-3933-11eb-832c-cfe953caf698.gif)
