### PR TITLE
Day overview styling improvements

### DIFF
--- a/backend/foodbank_southlondon/templates/day-overview.html
+++ b/backend/foodbank_southlondon/templates/day-overview.html
@@ -48,6 +48,9 @@
             tr.compact td {
                 padding: 0.05rem 0.2rem;
             }
+            .no-wrap {
+                white-space: nowrap;
+            }
         </style>
     </head>
     <body>
@@ -57,8 +60,7 @@
         </div>
         <table>
             <tr>
-                <th>Packed?</th>
-                <th>Sent?</th>
+                <th></th>
                 <th colspan="2">Name</th>
                 <th>Post Code</th>
                 <th colspan="2">Packing Date</th>
@@ -67,15 +69,22 @@
             </tr>
             {% for request in requests_items %}
             <tr class="compact">
-                <td></td>
-                <td></td>
+                <td>
+                    <span class="no-wrap">Packed ◻</span>
+                    <br />
+                    <span class="no-wrap">Sent ◻</span>
+                </td>
                 <td colspan="2">
                     {% if request['flag_for_attention'] %}
                         🚩
                     {% endif %}
                     {{ request['client_full_name'] }}
                 </td>
-                <td>{{ request['postcode'] }}</td>
+                <td>
+                    <span class="no-wrap">
+                        {{ request['postcode'] }}
+                    </span>
+                </td>
                 <td colspan="2">{{ request['packing_date'] }}</td>
                 <td>{{ request['time_of_day'] }}</td>
                 <td colspan="8">{{ request['delivery_instructions'] or '' }}</td>

--- a/backend/foodbank_southlondon/templates/day-overview.html
+++ b/backend/foodbank_southlondon/templates/day-overview.html
@@ -51,16 +51,17 @@
             .no-wrap {
                 white-space: nowrap;
             }
-            .status-icons {
+            .tickboxes {
                 display: flex;
-                flex-direction: column;
+                margin-top: 0.2rem;
             }
-            .status-icon {
-                display: flex;
-                justify-content: space-between;
-            }
-            .status-icon-description {
+            .tickbox {
+                width: 11px;
+                height: 11px;
                 font-size: 10px;
+                line-height: 10px;
+                margin-right: 0.2rem;
+                border: 1px solid black;
             }
         </style>
     </head>
@@ -74,29 +75,28 @@
                 <th></th>
                 <th colspan="2">Name</th>
                 <th>Post Code</th>
-                <th colspan="2">Packing Date</th>
                 <th>Time</th>
-                <th colspan="8">Instructions</th>
+                <th colspan="7">Instructions</th>
             </tr>
             {% for request in requests_items %}
             <tr class="compact">
                 <td>
-                    <div class="status-icons">
-                        <div class="status-icon">
-                            <div class="status-icon-description">Packed</div>
-                            <!-- Separate the checkbox so it is aligned to the right of the cell -->
-                            <div>◻</div>
-                        </div>
-                        <div class="status-icon">
-                            <div class="status-icon-description">Sent</div>
-                            <div>◻</div>
-                        </div>
+                    <div class="tickboxes">
+                        <!-- Packed -->
+                        <div class="tickbox"></div>
+                        <!-- Sent -->
+                        <div class="tickbox"></div>
+                        <!-- Use a placeholder to ensure everything lines up -->
+                        {% if request['flag_for_attention'] %}
+                            <div class="tickbox">
+                                <div>🚩</div>
+                            </div>
+                        {% else %}
+                            <div class="tickbox"></div>
+                        {% endif %}
                     </div>
                 </td>
                 <td colspan="2">
-                    {% if request['flag_for_attention'] %}
-                        🚩
-                    {% endif %}
                     {{ request['client_full_name'] }}
                 </td>
                 <td>
@@ -104,9 +104,8 @@
                         {{ request['postcode'] }}
                     </span>
                 </td>
-                <td colspan="2">{{ request['packing_date'] }}</td>
                 <td>{{ request['time_of_day'] }}</td>
-                <td colspan="8">{{ request['delivery_instructions'] or '' }}</td>
+                <td colspan="7">{{ request['delivery_instructions'] or '' }}</td>
             </tr>
             {% endfor %}
         </table>

--- a/backend/foodbank_southlondon/templates/day-overview.html
+++ b/backend/foodbank_southlondon/templates/day-overview.html
@@ -69,7 +69,12 @@
             <tr class="compact">
                 <td></td>
                 <td></td>
-                <td colspan="2">{{ request['client_full_name'] }}</td>
+                <td colspan="2">
+                    {% if request['flag_for_attention'] %}
+                        🚩
+                    {% endif %}
+                    {{ request['client_full_name'] }}
+                </td>
                 <td>{{ request['postcode'] }}</td>
                 <td colspan="2">{{ request['packing_date'] }}</td>
                 <td>{{ request['time_of_day'] }}</td>

--- a/backend/foodbank_southlondon/templates/day-overview.html
+++ b/backend/foodbank_southlondon/templates/day-overview.html
@@ -13,7 +13,7 @@
             }
             body {
                 font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-                font-size: 10px;
+                font-size: 12px;
                 line-height: 1.25rem;
             }
             h1 {
@@ -59,6 +59,9 @@
                 display: flex;
                 justify-content: space-between;
             }
+            .status-icon-description {
+                font-size: 10px;
+            }
         </style>
     </head>
     <body>
@@ -80,11 +83,13 @@
                 <td>
                     <div class="status-icons">
                         <div class="status-icon">
-                            <!-- Align the checkbox to the right of the cell -->
-                            <div>Packed</div><div>◻</div>
+                            <div class="status-icon-description">Packed</div>
+                            <!-- Separate the checkbox so it is aligned to the right of the cell -->
+                            <div>◻</div>
                         </div>
                         <div class="status-icon">
-                            <div>Sent</div><div>◻</div>
+                            <div class="status-icon-description">Sent</div>
+                            <div>◻</div>
                         </div>
                     </div>
                 </td>

--- a/backend/foodbank_southlondon/templates/day-overview.html
+++ b/backend/foodbank_southlondon/templates/day-overview.html
@@ -51,6 +51,14 @@
             .no-wrap {
                 white-space: nowrap;
             }
+            .status-icons {
+                display: flex;
+                flex-direction: column;
+            }
+            .status-icon {
+                display: flex;
+                justify-content: space-between;
+            }
         </style>
     </head>
     <body>
@@ -70,9 +78,15 @@
             {% for request in requests_items %}
             <tr class="compact">
                 <td>
-                    <span class="no-wrap">Packed ◻</span>
-                    <br />
-                    <span class="no-wrap">Sent ◻</span>
+                    <div class="status-icons">
+                        <div class="status-icon">
+                            <!-- Align the checkbox to the right of the cell -->
+                            <div>Packed</div><div>◻</div>
+                        </div>
+                        <div class="status-icon">
+                            <div>Sent</div><div>◻</div>
+                        </div>
+                    </div>
                 </td>
                 <td colspan="2">
                     {% if request['flag_for_attention'] %}


### PR DESCRIPTION
Styling improvements to the day overview

Before

<img width="951" alt="Screen Shot 2020-12-11 at 19 39 21" src="https://user-images.githubusercontent.com/395805/101947572-9a2ca280-3be8-11eb-98a8-ce71fdbdd4ef.png">

After

<img width="963" alt="Screen Shot 2021-01-10 at 11 48 18" src="https://user-images.githubusercontent.com/395805/104121956-10343e80-533a-11eb-9e18-ffa203049609.png">


- Replace the first column with a single cell with two checkboxes to save space
- Include the red flag for attention
- Bump the overall font size by 2px
  - I've left the Packed/Sent at 10px otherwise they end up on top of the checkbox
- Stop the postcode wrapping across lines
- Leave more space for the postcode by reducing the colspan for the instructions
- Remove packing date as it is always the same in a "Day Overview" report