### PR TITLE
Automatically focus the first input in each pop-up dialog

### DIFF
--- a/frontend/src/components/lists/item-form.jsx
+++ b/frontend/src/components/lists/item-form.jsx
@@ -159,7 +159,7 @@ export default class ListItemForm extends React.Component {
             <div className="item-form">
                 <div className="row">
                     <label>Description</label>
-                    <input type="text" value={ this.state.description } onChange={ this.updateDescription } />
+                    <input autoFocus type="text" value={ this.state.description } onChange={ this.updateDescription } />
                 </div>
                 { rows }
             </div>

--- a/frontend/src/components/requests/event-dialog.jsx
+++ b/frontend/src/components/requests/event-dialog.jsx
@@ -70,6 +70,7 @@ export default class RequestsEventDialog extends React.Component {
             return (
                 <div className="field-row">
                     <label>Date</label>
+                    {/* Don't try to autoFocus the date as we assume it has a sensible default */}
                     <DatePicker
                         selected={ this.state.date }
                         dateFormat={ DATE_FORMAT_UI }
@@ -83,7 +84,7 @@ export default class RequestsEventDialog extends React.Component {
             return (
                 <div className="field-row">
                     <label>Name</label>
-                    <input type="text" onChange={ this.updateName } />
+                    <input type="text" autoFocus={!this.requiresQuantity()} onChange={ this.updateName } />
                 </div>
             );
         }
@@ -91,7 +92,7 @@ export default class RequestsEventDialog extends React.Component {
             return (
                 <div className="field-row">
                     <label>Quantity</label>
-                    <input type="number" onChange={ this.updateQuantity } />
+                    <input type="number" autoFocus={!this.requiresName()} onChange={ this.updateQuantity } />
                 </div>
             );
         }


### PR DESCRIPTION
This was requested so people don't have to click in the Quantity field manually when printing shipping labels etc.

I've added `autoFocus` for each usage of the Popup rather than writing generic code within the Popup itself, which I think is the right choice providing we remember to consider it every time we make a new dialog