### PR TITLE
Darken the hover colour on the table

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -127,7 +127,7 @@ table {
         cursor: pointer;
 
         &:hover {
-            background: rgba(91, 159, 227, 0.4);
+            background: rgba(91, 159, 227, 0.6);
         }
     }
 


### PR DESCRIPTION
The current contrast is difficult to perceive on some cheaper monitors

**Before**

<img width="1212" alt="Screen Shot 2021-01-17 at 15 07 15" src="https://user-images.githubusercontent.com/395805/104847063-d92fd100-58d5-11eb-8666-b0b80f6f094d.png">

**After**

<img width="1213" alt="Screen Shot 2021-01-17 at 15 07 01" src="https://user-images.githubusercontent.com/395805/104847061-d7660d80-58d5-11eb-864a-12256d555363.png">
