### PR TITLE
Time and last status filter UX improvements

### DIFF
--- a/frontend/src/components/lists/value-filters.jsx
+++ b/frontend/src/components/lists/value-filters.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Menu from '../common/menu';
 import { fetchRequests, fetchTimeOfDayFilterValues, fetchEventsFilterValues } from '../../redux/actions';
-import { STATUS_LOADING } from '../../constants';
+import { STATUS_LOADING, STATUS_SUCCESS } from '../../constants';
 
-export function FilterFieldValues({ allPossibleValues, values, onChange, onOpen, loading }) {
+export function FilterFieldValues({ allPossibleValues, values, onChange, onOpen, loading, disabled }) {
     function getUpdatedValues(value) {
         if(values.includes(value)) {
             return values.filter(v => v !== value);
@@ -28,6 +28,7 @@ export function FilterFieldValues({ allPossibleValues, values, onChange, onOpen,
                         type="checkbox"
                         onChange={() => onChange(getUpdatedValues(value))}
                         checked={values.includes(value)}
+                        disabled={disabled}
                     ></input>
                     <label>{value}</label>
                 </React.Fragment>    
@@ -39,10 +40,11 @@ export function FilterFieldValues({ allPossibleValues, values, onChange, onOpen,
 
 export function FilterTimeOfDay() {
     const dispatch = useDispatch();
-    const { filters, timeOfDayFilterValues } = useSelector(state => state.requests);
+    const { filters, timeOfDayFilterValues, status } = useSelector(state => state.requests);
 
     return <FilterFieldValues
         loading={timeOfDayFilterValues.loadingStatus === STATUS_LOADING}
+        disabled={status !== STATUS_SUCCESS}
         allPossibleValues={timeOfDayFilterValues.items}
         values={filters['timeOfDay'] || []}
         onChange={(timeOfDay) => dispatch(fetchRequests({ ...filters, timeOfDay }, 1, false)) }
@@ -52,7 +54,7 @@ export function FilterTimeOfDay() {
 
 export function FilterStatus() {
     const dispatch = useDispatch();
-    const { filters, eventsFilterValues } = useSelector(state => state.requests);
+    const { filters, eventsFilterValues, status } = useSelector(state => state.requests);
 
     const allPossibleValues = eventsFilterValues.items
         .map(({ event_name }) => event_name)
@@ -62,6 +64,7 @@ export function FilterStatus() {
         icon="filter"
         allPossibleValues={allPossibleValues}
         loading={eventsFilterValues.loadingStatus === STATUS_LOADING}
+        disabled={status !== STATUS_SUCCESS}
         values={filters['statuses'] || []}
         onChange={(statuses) => dispatch(fetchRequests({ ...filters, statuses }, 1, false)) }
         onOpen={() => dispatch(fetchEventsFilterValues())}

--- a/frontend/src/components/requests/actions.jsx
+++ b/frontend/src/components/requests/actions.jsx
@@ -30,11 +30,11 @@ export default class RequestsActions extends React.Component {
                 <Menu options={statusOptions}
                     className="primary"
                     label="Statuses"
-                    disabled={ !this.props.recordCount } />
+                    disabled={ this.props.disabled || !this.props.recordCount } />
                 <Menu options={actionOptions}
                     className="primary"
                     label="Actions"
-                    disabled={ !this.props.recordCount } />
+                    disabled={ this.props.disabled || !this.props.recordCount } />
             </div>
         );
     }

--- a/frontend/src/components/requests/filter.jsx
+++ b/frontend/src/components/requests/filter.jsx
@@ -92,7 +92,12 @@ export default class RequestsFilter extends React.Component {
                         <Icon icon={ this.state.showAdditional ? 'chevron-up' : 'chevron-down' }
                             className="toggle-more-icon" />
                     </span>
-                    <button onClick={ () => this.submit() }>Go</button>
+                    <button
+                        onClick={ () => this.submit() }
+                        disabled={this.props.disabled}
+                    >
+                        Go
+                    </button>
                 </div>
                 { this.getAdditionalFilter() }
             </div>

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -130,11 +130,15 @@ class Requests extends React.Component {
     }
 
     getRequestsContents() {
+        const empty = this.props.items.length === 0;
+        const loading = this.props.status === STATUS_LOADING;
+
         return (
-            <div>
+            <div className="requests-contents">
+                {loading && !empty ? <div className="requests-blinder"></div> : false}
                 <RequestsList
                     requests={ this.props.items }
-                    loading={ this.props.status === STATUS_LOADING }
+                    loading={ loading }
                     onSelect={ id => this.selectRequest(id) }
                     onToggle={ id => this.toggleRequest(id) }
                     onToggleAll={ () => this.toggleAllRequests() }

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -53,8 +53,8 @@ class Requests extends React.Component {
         this.fetchRequests(this.props.filters, page);
     }
 
-    fetchRequests(filters = {}, page = 1, refreshCache = false) {
-        this.props.fetchRequests(filters, page, refreshCache);
+    fetchRequests(filters = {}, page = 1, refreshCache = false, clearItems = false) {
+        this.props.fetchRequests(filters, page, refreshCache, clearItems);
     }
 
     fetchEvents() {
@@ -107,7 +107,7 @@ class Requests extends React.Component {
 
     getFilter() {
         return <RequestsFilter
-            onSubmit={ v => this.fetchRequests(v) }
+            onSubmit={ v => this.fetchRequests(v, undefined, false, true) }
             value={ this.props.filters } />;
     }
 

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -40,10 +40,6 @@ class Requests extends React.Component {
         this.triggerSubmit = this.triggerSubmit.bind(this);
         this.confirmEventSubmission = this.confirmEventSubmission.bind(this);
         this.cancelEventSubmission = this.cancelEventSubmission.bind(this);
-
-        this.state = {
-            filters: {}
-        };
     }
 
     componentDidMount() {
@@ -54,11 +50,10 @@ class Requests extends React.Component {
     }
 
     selectPage(page) {
-        this.fetchRequests(this.state.filters, page);
+        this.fetchRequests(this.props.filters, page);
     }
 
     fetchRequests(filters = {}, page = 1, refreshCache = false) {
-        this.setState({ filters });
         this.props.fetchRequests(filters, page, refreshCache);
     }
 
@@ -85,11 +80,11 @@ class Requests extends React.Component {
     }
 
     triggerSubmit(event, type) {
-        this.props.triggerSubmitEvent(event, type, this.getSelectedIds(), this.state.filters, this.props.paging.page);
+        this.props.triggerSubmitEvent(event, type, this.getSelectedIds(), this.props.filters, this.props.paging.page);
     }
 
     confirmEventSubmission(event, type, data) {
-        this.props.confirmSubmitEvent(event, type, this.getSelectedIds(), data, this.state.filters, this.props.paging.page);
+        this.props.confirmSubmitEvent(event, type, this.getSelectedIds(), data, this.props.filters, this.props.paging.page);
     }
 
     cancelEventSubmission() {

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -4,8 +4,8 @@ import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import {
     STATUS_FAILED,
     STATUS_IDLE,
-    STATUS_LOADING,
-    STATUS_SUCCESS
+    STATUS_SUCCESS,
+    STATUS_LOADING
 } from '../../constants';
 import { getRequestsState } from '../../redux/selectors';
 import {
@@ -21,7 +21,6 @@ import {
     cancelSubmitEvent
 } from '../../redux/actions';
 import Paginator from '../common/paginator';
-import Loading from '../common/loading';
 import Error from '../common/error';
 import RequestsFilter from './filter';
 import RequestsList from './list';
@@ -103,10 +102,6 @@ class Requests extends React.Component {
             .map(item => item.data.id);
     }
 
-    isLoading() {
-        return this.props.status === STATUS_LOADING;
-    }
-
     isFailed() {
         return this.props.status === STATUS_FAILED;
     }
@@ -130,7 +125,6 @@ class Requests extends React.Component {
     }
 
     getContents() {
-        if (this.isLoading()) return <Loading />;
         if (this.isFailed()) return <Error message={'Unable to load requests'} />;
         return this.getRequestsContents();
     }
@@ -140,6 +134,7 @@ class Requests extends React.Component {
             <div>
                 <RequestsList
                     requests={ this.props.items }
+                    loading={ this.props.status === STATUS_LOADING }
                     onSelect={ id => this.selectRequest(id) }
                     onToggle={ id => this.toggleRequest(id) }
                     onToggleAll={ () => this.toggleAllRequests() }

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -105,28 +105,29 @@ class Requests extends React.Component {
         return this.props.status === STATUS_SUCCESS;
     }
 
-    getFilter() {
+    getFilter(loading) {
         return <RequestsFilter
+            disabled={loading}
             onSubmit={ v => this.fetchRequests(v, undefined, false, true) }
             value={ this.props.filters } />;
     }
 
-    getActions() {
+    getActions(loading) {
         return <RequestsActions
             recordCount={ this.getSelectedIds().length }
             statuses={ this.props.statuses }
             actions={ this.props.actions }
+            disabled={loading}
             onAction={ (action, type) => this.triggerSubmit(action, type) } />;
     }
 
-    getContents() {
+    getContents(loading) {
         if (this.isFailed()) return <Error message={'Unable to load requests'} />;
-        return this.getRequestsContents();
+        return this.getRequestsContents(loading);
     }
 
-    getRequestsContents() {
+    getRequestsContents(loading) {
         const empty = this.props.items.length === 0;
-        const loading = this.props.status === STATUS_LOADING;
 
         return (
             <div className="requests-contents">
@@ -177,11 +178,12 @@ class Requests extends React.Component {
     }
 
     render() {
+        const loading = this.props.status === STATUS_LOADING;
 
-        const filter = this.getFilter();
-        const actions = this.getActions();
+        const filter = this.getFilter(loading);
+        const actions = this.getActions(loading);
 
-        const contents = this.getContents();
+        const contents = this.getContents(loading);
 
         const selection = this.getRequestSelection();
 

--- a/frontend/src/components/requests/list.jsx
+++ b/frontend/src/components/requests/list.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { format } from 'date-fns';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import { DATE_FORMAT_UI } from '../../constants';
 import Flag from './flag';
-import Sync from './sync';
 import CongestionCharge from '../common/congestion-charge';
 import './styles/list.scss';
 import { FilterTimeOfDay, FilterStatus } from '../lists/value-filters';
+import Loading from '../common/loading';
 
 export default class RequestsList extends React.Component {
 
@@ -36,9 +37,17 @@ export default class RequestsList extends React.Component {
     getEmptyRow() {
         return (
             <tr className="empty-row">
-                <td colSpan="6">No results</td>
+                <td colSpan="6">
+                    {this.props.loading ? <Loading /> : "No results"}
+                </td>
             </tr>
         );
+    }
+
+    refresh = () => {
+        if(!this.props.loading) {
+            this.props.onRefresh();
+        }
     }
 
     render() {
@@ -118,8 +127,12 @@ export default class RequestsList extends React.Component {
                                 <div className="cell-actions">
                                     <FilterStatus />
                                 </div>
-                                <button onClick={this.props.onRefresh}>
-                                    <Sync />
+                                <button onClick={this.refresh}>
+                                    <Icon
+                                        icon="sync"
+                                        title="Refresh"
+                                        spin={this.props.loading}
+                                    />
                                 </button>
                             </div>
                         </th>

--- a/frontend/src/components/requests/styles/index.scss
+++ b/frontend/src/components/requests/styles/index.scss
@@ -1,13 +1,14 @@
 @import 'include';
 
 .requests-container {
-
     .requests-header {
         position: sticky;
         top: -1px;
         display: flex;
         align-items: flex-start;
         background-color: $colour-white;
+        // Ensure the React datepicker appears above other content
+        z-index: 1;
     }
 
     .requests-controls {
@@ -21,5 +22,19 @@
                 margin-right: $pad-half;
             }
         }
+    }
+
+    .requests-contents {
+        // To support the blinder covering the entire element
+        position: relative;
+        z-index: 0;
+    }
+
+    .requests-blinder {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        background: rgba($colour-background-bold, .5);
+        z-index: 1;
     }
 }

--- a/frontend/src/components/requests/sync.jsx
+++ b/frontend/src/components/requests/sync.jsx
@@ -1,6 +1,0 @@
-import React from 'react';
-import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
-
-export default function Sync() {
-    return <Icon icon="sync" title="Refresh" />;
-}

--- a/frontend/src/redux/actions/index.js
+++ b/frontend/src/redux/actions/index.js
@@ -58,20 +58,21 @@ import {
 
 // Requests
 
-export const fetchRequests = (filters, page, refreshCache) => {
+export const fetchRequests = (filters, page, refreshCache, clearItems) => {
     return dispatch => {
-        dispatch(loadRequests(filters, page));
+        dispatch(loadRequests(filters, page, clearItems));
         return getRequests(filters, page, refreshCache)
             .then(({ result, paging, editUrl }) => dispatch(requestsLoaded(result, paging, editUrl)))
             .catch(() => dispatch(loadRequestsFailed()));
     };
 };
 
-export const loadRequests = (filters, page) => ({
+export const loadRequests = (filters, page, clearItems) => ({
     type: LOAD_REQUESTS,
     payload: {
         filters,
-        page
+        page,
+        clearItems
     }
 });
 

--- a/frontend/src/redux/reducers/requests.js
+++ b/frontend/src/redux/reducers/requests.js
@@ -82,14 +82,32 @@ const initialState = {
 export default function(state = initialState, action) {
     switch (action.type) {
 
-        case LOAD_REQUESTS:
+        case LOAD_REQUESTS: {
+            // paging and items stay when editing column filters, although the
+            // UI will not allow further edits until the load is complete
+            let pagingAndItems = {};
+
+            if(action.payload.clearItems) {
+                pagingAndItems = {
+                        paging: {
+                        ...state.paging,
+                        page: action.payload.page,
+                        totalPages: 0,
+                        totalItems: 0,
+                        pageSize: 0
+                    },
+                    items: []
+                }
+            }
+
             return {
                 ...state,
+                ...pagingAndItems,
                 filters: action.payload.filters,
-                status: STATUS_LOADING,
-                // paging and items stay, although the UI will not
-                // allow edits until the load is complete
+                status: STATUS_LOADING
             };
+        }
+
         case REQUESTS_LOADED:
             return {
                 ...state,

--- a/frontend/src/redux/reducers/requests.js
+++ b/frontend/src/redux/reducers/requests.js
@@ -87,14 +87,8 @@ export default function(state = initialState, action) {
                 ...state,
                 filters: action.payload.filters,
                 status: STATUS_LOADING,
-                paging: {
-                    ...state.paging,
-                    page: action.payload.page,
-                    totalPages: 0,
-                    totalItems: 0,
-                    pageSize: 0
-                },
-                items: []
+                // paging and items stay, although the UI will not
+                // allow edits until the load is complete
             };
         case REQUESTS_LOADED:
             return {


### PR DESCRIPTION
This PR makes the column value filters behave more intuitively, like Google Sheets:

- Ticking a filter doesn't close the dropdown
- Those filters stay applied after an event is triggered

Previously the entire table UI disappeared when loading data. Now the data is greyed out but remains when you change filters or refresh but is cleared out if you click "Go". The theory here is that "Go" means you're looking for something entirely different so it's distracting to leave the old stuff there whereas changing the filters or triggering an event apply to the data you already have.

I've gone for the simplest implementation that disallows any other actions when loading is in progress. This will be annoying if you want to tick multiple filters and it's not that hard to make it work (debounce the request and ignore the results from any previously in flight). I'm also a little worried that disabling the "Go" and refresh buttons during a load will cause other issues. Lets see what users say.

https://user-images.githubusercontent.com/395805/112761566-c8958880-8ff3-11eb-98c9-454ac2b13af4.mov

https://user-images.githubusercontent.com/395805/112761636-127e6e80-8ff4-11eb-9437-05f2dcffe0c6.mov

https://user-images.githubusercontent.com/395805/112761479-6fc5f000-8ff3-11eb-83f0-d1c04cce647f.mov

